### PR TITLE
Comma delimited assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Options:
   -b, --body              text of release body
   -o, --owner             repo owner
   -r, --repo              repo name
-  -d, --draft             publish as draft                     [default: false]
-  -p, --prerelease        publish as prerelease                [default: false]
-  --dry-run               dry run (stops before release step)  [default: false]
-  -w, --workpath          path to working directory            [default: "<current working directory>"]
-  -e, --endpoint          GitHub API endpoint URL              [default: "https://api.github.com"]
-  -a, --assets            list of assets to upload to release  [default: false]
+  -d, --draft             publish as draft                          [default: false]
+  -p, --prerelease        publish as prerelease                     [default: false]
+  --dry-run               dry run (stops before release step)       [default: false]
+  -w, --workpath          path to working directory                 [default: "<current working directory>"]
+  -e, --endpoint          GitHub API endpoint URL                   [default: "https://api.github.com"]
+  -a, --assets            comma-delimited list of assets to upload  [default: false]
   -h, --help              Show help
   -v, --version           Show version number
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,7 +33,9 @@ var ghauthOpts = {
 }
 
 if (argv.assets) {
-  argv.assets = argv.assets.split(',')
+  argv.assets = argv.assets.split(',').map(function (asset) {
+    return asset.trim()
+  })
 }
 
 ghauth(ghauthOpts, function (err, auth) {


### PR DESCRIPTION
It wasn't obvious to me that I could use commas to specify multiple asset paths. This makes the CLI usage a bit more obvious, and allows spaces after the commas.

Fixes #52 