### PR TITLE
warn when package.json url is out of date

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -96,6 +96,11 @@ ghauth(ghauthOpts, function (err, auth) {
         // handle errors
         if (err) return handleError(err)
 
+        if (result.message === 'Moved Permanently') {
+          console.error('repository url in package.json is out of date and requires a redirect')
+          process.exit(1)
+        }
+
         if (!result || !result.html_url) {
           console.error('missing result info')
           process.exit(1)


### PR DESCRIPTION
i did quite a bit of head scratching when gh-release failed in a project where my package.json was stale after a repo rename because we currently swallow the response below.

```js
{ message: 'Moved Permanently',
  url: 'https://api.github.com/repositories/48707919/releases',
  documentation_url: 'https://developer.github.com/v3/#http-redirects' }
```

i've invited y'all as collaborators in [`leaflet.foo.bar`](https://github.com/jgravois/leaflet.foo.bar) (which was formerly named `leaflet.foo`) in case you'd like to test the fix somewhere safe and convenient yourselves.

i don't _think_ there's a place in the existing test suite to add something like this, but happy to be proven wrong.