### PR TITLE
catch 'bracketed' unreleased changelog entries (eg. '[Unreleased]')

### DIFF
--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -21,7 +21,7 @@ function getDefaults (workPath, callback) {
 
     var unreleased = result.versions.filter(function (release) {
       return release.title && release.title.toLowerCase
-        ? release.title.toLowerCase() === 'unreleased'
+        ? release.title.toLowerCase().indexOf('unreleased') !== -1
         : false
     })
 

--- a/test/fixtures/unreleased-alt/CHANGELOG.md
+++ b/test/fixtures/unreleased-alt/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [Unreleased]
+
+## 1.0.0
+- bananas

--- a/test/fixtures/unreleased-alt/package.json
+++ b/test/fixtures/unreleased-alt/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gh-release-test",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bcomnes/gh-release-test.git"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -22,9 +22,14 @@ test('should return error if changelog version !== package.json version', functi
 })
 
 test('should return error if unreleased section exists', function (t) {
-  t.plan(1)
+  t.plan(2)
   ghRelease({
     workpath: fixture('unreleased')
+  }, function (err, result) {
+    t.deepEqual(err.message, 'Unreleased changes detected in CHANGELOG.md, aborting')
+  })
+  ghRelease({
+    workpath: fixture('unreleased-alt')
   }, function (err, result) {
     t.deepEqual(err.message, 'Unreleased changes detected in CHANGELOG.md, aborting')
   })


### PR DESCRIPTION
@ungoldman

Notes:
- Implementation of featured requested in issue #65 
- Code style passes linter.
- Tests updated and passing.