### PR TITLE
Support non-interactive continuous-delivery system use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Project versioning adheres to [Semantic Versioning](http://semver.org/).
 Commit convention is based on [Conventional Commits](http://conventionalcommits.org).
 Change log format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+
+### Additions
+
+- `no-prompt` CLI option to skip the release prompt
+- Support for reading the GitHub access token from the `GH_RELEASE_GITHUB_API_TOKEN` environment variable
+
 ## [3.2.3](https://github.com/hypermodules/gh-release/compare/v3.2.2...v3.2.3) - 2018-08-30
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Change log format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Additions
 
-- `--noconfirm` CLI option to skip the release confirmation prompt
+- `--yes` CLI option to skip the release confirmation prompt
 - Support for reading the GitHub access token from the `GH_RELEASE_GITHUB_API_TOKEN` environment variable
 
 ## [3.2.3](https://github.com/hypermodules/gh-release/compare/v3.2.2...v3.2.3) - 2018-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Change log format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Additions
 
-- `no-prompt` CLI option to skip the release prompt
+- `--noconfirm` CLI option to skip the release confirmation prompt
 - Support for reading the GitHub access token from the `GH_RELEASE_GITHUB_API_TOKEN` environment variable
 
 ## [3.2.3](https://github.com/hypermodules/gh-release/compare/v3.2.2...v3.2.3) - 2018-08-30

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Expects a `package.json` and `CHANGELOG.md` in the working directory.
 
 Prints release URL to `stdout` on success.
 
-Uses [`ghauth`](https://github.com/rvagg/ghauth) for authentication with Github. A Github API OAuth token is saved to the `gh-release` config directory after the first time authenticating. Note that the config directory is determined by [`application-config`](https://github.com/LinusU/node-application-config) and is OS-specific.
+Uses [`ghauth`](https://github.com/rvagg/ghauth) for authentication with Github. A Github API OAuth token is saved to the `gh-release` config directory after the first time authenticating. Note that the config directory is determined by [`application-config`](https://github.com/LinusU/node-application-config) and is OS-specific. gh-release will alternatively use the token specified in the `GH_RELEASE_GITHUB_API_TOKEN` environment variable if it exists. This allows it to be used in continuous deployment systems, which can inject different GitHub API tokens depending on the location of the project.
 
 Get usage info by running with `--help` or `-h`.
 
@@ -82,6 +82,7 @@ Options:
   -e, --endpoint          GitHub API endpoint URL                   [default: "https://api.github.com"]
   -a, --assets            comma-delimited list of assets to upload  [default: false]
   --dry-run               dry run (stops before release step)       [default: false]
+  --noconfirm             bypass confirmation prompt for release    [default: false]
   -h, --help              Show help
   -v, --version           Show version number
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
   -e, --endpoint          GitHub API endpoint URL                   [default: "https://api.github.com"]
   -a, --assets            comma-delimited list of assets to upload  [default: false]
   --dry-run               dry run (stops before release step)       [default: false]
-  --noconfirm             bypass confirmation prompt for release    [default: false]
+  -y, --yes               bypass confirmation prompt for release    [default: false]
   -h, --help              Show help
   -v, --version           Show version number
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -47,9 +47,18 @@ if (argv.assets) {
   })
 }
 
-ghauth(ghauthOpts, function (err, auth) {
-  if (err) return handleError(err)
+if (process.env.GH_RELEASE_GITHUB_API_TOKEN) {
+  releaseWithAuth({
+    token: process.env.GH_RELEASE_GITHUB_API_TOKEN
+  })
+} else {
+  ghauth(ghauthOpts, function (err, auth) {
+    if (err) return handleError(err)
+    releaseWithAuth(auth)
+  })
+}
 
+function releaseWithAuth (auth) {
   var options = {}
   options.auth = auth
   options.cli = true
@@ -83,6 +92,9 @@ ghauth(ghauthOpts, function (err, auth) {
 
     if (options.dryRun) process.exit(0)
 
+    if (options.noconfirm) {
+      return performRelease(options)
+    }
     // confirm & release
 
     var confirmation = [{
@@ -98,30 +110,33 @@ ghauth(ghauthOpts, function (err, auth) {
 
     inquirer.prompt(confirmation, function (answers) {
       if (!answers.confirm) return process.exit(1)
-
-      // pass options to api
-
-      ghRelease(options, function ghReleaseCallback (err, result) {
-        // handle errors
-        if (err) return handleError(err)
-
-        if (result.message === 'Moved Permanently') {
-          console.error('repository url in package.json is out of date and requires a redirect')
-          process.exit(1)
-        }
-
-        if (!result || !result.html_url) {
-          console.error('missing result info')
-          process.exit(1)
-        }
-
-        // log release url & exit 0
-        console.log(result.html_url)
-        process.exit(0)
-      })
+      performRelease(options)
     })
   })
-})
+}
+
+function performRelease (options) {
+  // pass options to api
+
+  ghRelease(options, function ghReleaseCallback (err, result) {
+    // handle errors
+    if (err) return handleError(err)
+
+    if (result.message === 'Moved Permanently') {
+      console.error('repository url in package.json is out of date and requires a redirect')
+      process.exit(1)
+    }
+
+    if (!result || !result.html_url) {
+      console.error('missing result info')
+      process.exit(1)
+    }
+
+    // log release url & exit 0
+    console.log(result.html_url)
+    process.exit(0)
+  })
+}
 
 function handleError (err) {
   var msg = err.msg || err

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -92,7 +92,7 @@ function releaseWithAuth (auth) {
 
     if (options.dryRun) process.exit(0)
 
-    if (options.noconfirm) {
+    if (options.yes) {
       return performRelease(options)
     }
     // confirm & release

--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -51,7 +51,7 @@ function getDefaults (workPath, isEnterprise, callback) {
       owner: owner,
       repo: repo,
       dryRun: false,
-      noconfirm: false,
+      yes: false,
       endpoint: 'https://api.github.com',
       workpath: process.cwd(),
       prerelease: false,

--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -51,6 +51,7 @@ function getDefaults (workPath, isEnterprise, callback) {
       owner: owner,
       repo: repo,
       dryRun: false,
+      noconfirm: false,
       endpoint: 'https://api.github.com',
       workpath: process.cwd(),
       prerelease: false,

--- a/bin/lib/preview.js
+++ b/bin/lib/preview.js
@@ -24,6 +24,7 @@ function formatOptions (options) {
   delete copy.owner
   delete copy.repo
   delete copy.dryRun
+  delete copy.noconfirm
   delete copy.workpath
 
   var keys = Object.keys(copy).reverse()

--- a/bin/lib/preview.js
+++ b/bin/lib/preview.js
@@ -24,7 +24,7 @@ function formatOptions (options) {
   delete copy.owner
   delete copy.repo
   delete copy.dryRun
-  delete copy.noconfirm
+  delete copy.yes
   delete copy.workpath
 
   var keys = Object.keys(copy).reverse()

--- a/bin/lib/yargs.js
+++ b/bin/lib/yargs.js
@@ -67,7 +67,8 @@ module.exports = require('yargs')
       default: false,
       describe: 'dry run (stops before release step)'
     },
-    'noconfirm': {
+    'y': {
+      alias: 'yes',
       type: 'boolean',
       default: false,
       describe: 'bypass confirmation prompt for release'

--- a/bin/lib/yargs.js
+++ b/bin/lib/yargs.js
@@ -66,6 +66,11 @@ module.exports = require('yargs')
       type: 'boolean',
       default: false,
       describe: 'dry run (stops before release step)'
+    },
+    'noconfirm': {
+      type: 'boolean',
+      default: false,
+      describe: 'bypass confirmation prompt for release'
     }
   })
   .example('$0 -n v' + version + ' -c master -d', 'create a draft release with title v' + version + ' tagged at HEAD of master')

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var OPTIONS = {
   valid: [],
   defaults: {
     'dryRun': false,
-    'noconfirm': false,
+    'yes': false,
     'draft': false,
     'endpoint': 'https://api.github.com',
     'prerelease': false,
@@ -33,7 +33,7 @@ var OPTIONS = {
     'tag_name',
     'name',
     'dryRun',
-    'noconfirm',
+    'yes',
     'draft',
     'endpoint',
     'prerelease',

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var OPTIONS = {
   valid: [],
   defaults: {
     'dryRun': false,
+    'noconfirm': false,
     'draft': false,
     'endpoint': 'https://api.github.com',
     'prerelease': false,
@@ -32,6 +33,7 @@ var OPTIONS = {
     'tag_name',
     'name',
     'dryRun',
+    'noconfirm',
     'draft',
     'endpoint',
     'prerelease',


### PR DESCRIPTION
This PR adds the following to the gh-release CLI:

- A `--noconfirm` flag for skipping the confirmation prompt (modeled after Arch Linux' pacman's `--noconfirm`)
- The ability to read an authentication token from the `GH_RELEASE_GITHUB_API_TOKEN` environment variable

These two features combined allow for gh-release to be used in continuous-delivery systems (like Jenkins) where user interaction is not possible.  It also allows these systems to work with multiple GitHub APIs (i.e. github.com and a self-hosted Enterprise GitHub) by simply swapping out the token environment variable.

Resolves #75 