### PR TITLE
update inquirer and deep-extend to fix reported vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "changelog-parser": "^2.0.0",
-    "deep-extend": "^0.3.3",
+    "deep-extend": "^0.6.0",
     "gh-release-assets": "^1.1.0",
     "ghauth": "^3.2.0",
     "github-url-to-object": "^3.0.0",
-    "inquirer": "^0.8.0",
+    "inquirer": "^6.2.0",
     "request": "^2.82.0",
     "shelljs": "^0.3.0",
     "update-notifier": "^2.2.0",


### PR DESCRIPTION
npm is reporting security vulnerabilities for gh-release when installed due to some out of date deps.

The tests pass, and only one method is used from inquirer, so even though this update would skip like 5 major versions the interface for that method is the same and it should work fine. 