### PR TITLE
#78 - use promise syntax for inquirer prompt

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -108,7 +108,7 @@ function releaseWithAuth (auth) {
       }
     }]
 
-    inquirer.prompt(confirmation, function (answers) {
+    inquirer.prompt(confirmation).then(function (answers) {
       if (!answers.confirm) return process.exit(1)
       performRelease(options)
     })


### PR DESCRIPTION
Inquirer now uses the promise syntax.

/cc @bcomnes @rgwozdz 