### PR TITLE
Add an asset upload progress indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chalk": "^1.0.0",
     "changelog-parser": "^2.0.0",
     "deep-extend": "^0.6.0",
+    "gauge": "^2.7.4",
     "gh-release-assets": "^1.1.0",
     "ghauth": "^3.2.0",
     "github-url-to-object": "^3.0.0",


### PR DESCRIPTION
This PR adds an asset upload progress indicator to gh-release by returning an `EventEmitter` from the `Release` function and proxying the events emitted by gh-release-assets out to the consumer.  It also adds a progress bar to the CLI via the [gauge](https://github.com/iarna/gauge) library.  I've tested this against a personal repo uploading multiple files of various sizes and it all looks good!  Let me know if anything should be changed or updated!

Resolves #49 