### PR TITLE
Fix unhandled exception when changelog contains no versions

### DIFF
--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -37,6 +37,9 @@ function getDefaults (workPath, isEnterprise, callback) {
 
     var log = result.versions.filter(function (release) { return release.version !== null })[0]
 
+    if (!log) {
+      return callback(new Error('CHANGELOG.md does not contain any versions'))
+    }
     if (log.version !== pkg.version) {
       var errStr = 'CHANGELOG.md out of sync with package.json '
       errStr += '(' + (log.version || log.title) + ' !== ' + pkg.version + ')'

--- a/test/fixtures/no-versions/CHANGELOG.md
+++ b/test/fixtures/no-versions/CHANGELOG.md
@@ -1,0 +1,1 @@
+## Unreleased

--- a/test/fixtures/no-versions/package.json
+++ b/test/fixtures/no-versions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gh-release-test",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bcomnes/gh-release-test.git"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,15 @@ test('should return error if a non-empty unreleased section exists', function (t
   })
 })
 
+test('should return error if no versions exist', function (t) {
+  t.plan(1)
+  ghRelease({
+    workpath: fixture('no-versions')
+  }, function (err, result) {
+    t.deepEqual(err.message, 'CHANGELOG.md does not contain any versions')
+  })
+})
+
 test('should allow empty unreleased sections', function (t) {
   var errStr = 'Unreleased changes detected in CHANGELOG.md, aborting'
   t.plan(1)


### PR DESCRIPTION
This PR fixes an unhandled exception when the CHANGELOG.md file doesn't contain any versions and instead returns an understandable error message.