### PR TITLE
when an array of errors are returned, ensure they are readable

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -155,7 +155,7 @@ function performRelease (options) {
 }
 
 function handleError (err) {
-  var msg = err.msg || err
+  var msg = err.msg || JSON.stringify(err)
   console.log(chalk.red(msg))
   process.exit(1)
 }


### PR DESCRIPTION
GitHub sometimes returns an array of errors instead of just one. this tweak ensures that they can be quickly parsed visually.

related: #82

```bash
> [object Object],[object Object],[object Object]
```
becomes
```bash
> [{"resource":"Release","code":"custom","field":"tag_name","message":"tag_name is not a valid tag"},{"resource":"Release","code":"custom","message":"Published releases must have a valid tag"},{"resource":"Release","code":"invalid","field":"target_commitish"}]
# etc. etc. 
```