### PR TITLE
feat: allow passing asset object as gh-release-assets supports

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,13 @@ function _Release (options, emitter, callback) {
 
       if (options.assets) {
         var assets = options.assets.map(function (asset) {
+          if (typeof asset === 'object') {
+            return {
+              name: asset.name,
+              path: path.join(options.workpath, asset.path)
+            }
+          }
+
           return path.join(options.workpath, asset)
         })
 


### PR DESCRIPTION
This updates `gh-release` to allow passing `assets` as an object (for [asset renaming](https://github.com/hypermodules/gh-release-assets#usage))) when used in a Node script. Currently, you'll get the following error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object
    at validateString (internal/validators.js:121:11)
    at Object.join (path.js:1039:7)
    at /.../calcite-components/node_modules/gh-release/index.js:138:23
    at Array.map (<anonymous>)
    at Request._callback (/.../calcite-components/node_modules/gh-release/index.js:137:37)
    at Request.self.callback (/.../calcite-components/node_modules/request/request.js:185:22)
    at Request.emit (events.js:314:20)
    at Request.EventEmitter.emit (domain.js:486:12)
    at Request.<anonymous> (/.../calcite-components/node_modules/request/request.js:1154:10)
    at Request.emit (events.js:314:20)
```

I did not find any tests that include assets, but I would gladly add some if I can get some guidance in that space.