### PR TITLE
Install object-assign to cover for gauge bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     "Ted Janeczko <tjaneczko@brightcove.com>"
   ],
   "dependencies": {
+    "@bret/ghauth": "^5.0.0",
     "chalk": "^4.1.0",
     "changelog-parser": "^2.0.0",
     "deep-extend": "^0.6.0",
     "gauge": "^3.0.0",
     "gh-release-assets": "^1.1.0",
-    "@bret/ghauth": "^5.0.0",
     "github-url-to-object": "^4.0.4",
     "inquirer": "^7.3.3",
+    "object-assign": "^4.1.1",
     "request": "^2.82.0",
     "shelljs": "^0.8.4",
     "update-notifier": "^4.1.0",


### PR DESCRIPTION
Gauge requires object-assign, but doesn't require it.   It often 'just works' but in some cases it does not.  Floating this until the following gets merged:

https://github.com/npm/gauge/pull/125