### PR TITLE
Use octokit instead of simple-get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Change log format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Republish of 4.0.3 due to a bad beta version publish on the latest npm tag.
 
+## [4.0.4-beta.0](https://github.com/hypermodules/gh-release/compare/v4.0.3...v4.0.4-beta.0) - 2020-12-04
+
+- Replace `simple-get` with `@octokit/rest`. This should fix some spurious timeout bugs.
+
 ## [4.0.3](https://github.com/hypermodules/gh-release/compare/v4.0.2...v4.0.3) - 2020-09-30
 
 - update-notifier version 5.0.0 (drops old node, and bugfixes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Project versioning adheres to [Semantic Versioning](http://semver.org/).
 Commit convention is based on [Conventional Commits](http://conventionalcommits.org).
 Change log format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [4.0.5-beta.0](https://github.com/hypermodules/gh-release/compare/v4.0.4...v4.0.5-beta.0) - 2020-12-04
+
+- Replace `simple-get` with `@octokit/rest`. This should fix some spurious timeout bugs.
+- Republish on correct npm channel.
+
 ## [4.0.4](https://github.com/hypermodules/gh-release/compare/v4.0.3...v4.0.4) - 2020-12-04
 
 - Republish of 4.0.3 due to a bad beta version publish on the latest npm tag.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -157,7 +157,7 @@ function performRelease (options) {
 }
 
 function handleError (err) {
-  const msg = err.message || JSON.stringify(err, null, '  ')
+  const msg = err.message || JSON.stringify(err, null, 2)
   console.log(chalk.red(msg))
   process.exit(1)
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -157,7 +157,7 @@ function performRelease (options) {
 }
 
 function handleError (err) {
-  const msg = err.message || JSON.stringify(err)
+  const msg = err.message || JSON.stringify(err, null, '  ')
   console.log(chalk.red(msg))
   process.exit(1)
 }

--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ function _Release (options, emitter, callback) {
         callback(null, results.data)
       }
     }).catch(err => {
+      // Create Release error handling
       if (err.status === 404) {
         const notFoundError = new Error(format('404 Not Found.  Review gh-release oAuth Organization access: https://github.com/settings/connections/applications/%s', clientId))
         notFoundError.wrapped = err
@@ -158,9 +159,7 @@ function _Release (options, emitter, callback) {
         const errorMessage = format('Release already exists for tag %s in %s/%s', options.tag_name, options.owner, options.repo)
         return callback(new Error(errorMessage))
       }
-
-      // Create Release error handling
-      callback(err)
+      return callback(err)
     })
   }).catch(err => {
     // Check target error handling

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "Ted Janeczko <tjaneczko@brightcove.com>"
   ],
   "dependencies": {
-    "ghauth": "^5.0.0",
+    "@octokit/rest": "^18.0.9",
     "chalk": "^4.1.0",
     "changelog-parser": "^2.0.0",
     "deep-extend": "^0.6.0",
     "gauge": "^v2.7.4",
     "gh-release-assets": "^2.0.0",
+    "ghauth": "^5.0.0",
     "github-url-to-object": "^4.0.4",
     "inquirer": "^7.3.3",
     "shelljs": "^0.8.4",
-    "simple-get": "^4.0.0",
     "update-notifier": "^5.0.0",
     "yargs": "^16.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gh-release",
   "description": "Create a release for a node package on github.",
-  "version": "4.0.4",
+  "version": "4.0.5-beta.0",
   "author": "Nate Goldman <ungoldman@gmail.com> (http://ungoldman.com/)",
   "bin": {
     "gh-release": "./bin/cli.js"


### PR DESCRIPTION
For some reason, simple-get would just timeout when using gh-release on some orgs.  I thought it was an issue with the device token permissions, but its not.  The GitHub API is weird, and finicky, and IME using octokit, despite its constant churn, is probably the best approach here.  It also generally improves errors that get returned, though most of our error handling I left the same.

I've tested the following scenarios:
- Normal working scenario
- Missing tag
- Bad credentials
- Asset uploads

Everything still seems to work.