### PR TITLE
allow unreleased CHANGELOG section if all subsections are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Project versioning adheres to [Semantic Versioning](http://semver.org/).
 Commit convention is based on [Conventional Commits](http://conventionalcommits.org).
 Change log format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+- Allow unreleased CHANGELOG section if all subsections are empty
+
 ## [5.0.0](https://github.com/hypermodules/gh-release/compare/v4.0.5-beta.0...v5.0.0) - 2021-01-16
 
 - A release of 4.0.5-beta.0 as a breaking change

--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -33,7 +33,7 @@ function getDefaults (workPath, isEnterprise, callback) {
         ? release.title.toLowerCase().indexOf('unreleased') !== -1
         : false
     }).filter(function (release) {
-      return !!release.body
+      return Object.values(release.parsed).flat().length > 0
     })
 
     if (unreleased.length > 0) {

--- a/test/fixtures/unreleased-empty-subsections/CHANGELOG.md
+++ b/test/fixtures/unreleased-empty-subsections/CHANGELOG.md
@@ -1,0 +1,17 @@
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+### Fixed
+
+### Security
+
+
+## 1.0.0
+- bananas

--- a/test/fixtures/unreleased-empty-subsections/package.json
+++ b/test/fixtures/unreleased-empty-subsections/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gh-release-test",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bcomnes/gh-release-test.git"
+  }
+}

--- a/test/get-defaults-test.js
+++ b/test/get-defaults-test.js
@@ -55,6 +55,15 @@ test('get-defaults supports package.json with an enterprise repo', function (t) 
   })
 })
 
+test('get-defaults allows CHANGELOGs with empty fixtures', function (t) {
+  t.plan(3)
+  getDefaults(path.join(__dirname, 'fixtures/unreleased-empty-subsections'), true, function (err, defaults) {
+    t.equal(err, null, 'error should be null')
+    t.equal(defaults.owner, 'bcomnes', 'gets owner from package.json')
+    t.equal(defaults.repo, 'gh-release-test', 'gets repo from package.json')
+  })
+})
+
 test('get-defaults errors out with an invalid repository URL', function (t) {
   t.plan(1)
   getDefaults(path.join(__dirname, 'fixtures/invalid-repo'), false, function (err, defaults) {

--- a/test/index.js
+++ b/test/index.js
@@ -58,3 +58,13 @@ test('should allow empty unreleased sections', function (t) {
     t.notEqual(err.message, errStr)
   })
 })
+
+test('should allow empty unreleased sub-sections', function (t) {
+  const errStr = 'Unreleased changes detected in CHANGELOG.md, aborting'
+  t.plan(1)
+  ghRelease({
+    workpath: fixture('unreleased-empty-subsections')
+  }, function (err, result) {
+    t.notEqual(err.message, errStr)
+  })
+})


### PR DESCRIPTION
My team likes to keep the 6 subsection headings from [keepachangelog](https://keepachangelog.com/en/1.0.0/#how) in `CHANGELOG.md` that way we don't have to remember the categories. This change only prevents the release if there are any bullets in any of the subsections.