### PR TITLE
Replace static "require" to dynamic "read"

### DIFF
--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -5,7 +5,7 @@ const exec = require('shelljs').exec
 const parseRepo = require('github-url-to-object')
 
 function getDefaults (workPath, isEnterprise, callback) {
-  const pkg = require(path.resolve(workPath, 'package.json'))
+  const pkg = readJson(path.resolve(workPath, 'package.json'))
   const lernaPath = path.resolve(workPath, 'lerna.json')
 
   if (!Object.hasOwnProperty.call(pkg, 'repository')) {
@@ -49,7 +49,7 @@ function getDefaults (workPath, isEnterprise, callback) {
     let lerna = {}
     let errStr
     if (fs.existsSync(lernaPath)) {
-      lerna = require(lernaPath) /* || {} */ // 👈 though I prefer this expression
+      lerna = readJson(lernaPath) /* || {} */ // 👈 though I prefer this expression
       if (log.version !== lerna.version) {
         errStr = 'CHANGELOG.md out of sync with lerna.json '
         errStr += '(' + (log.version || log.title) + ' !== ' + lerna.version + ')'
@@ -85,6 +85,10 @@ function getTargetCommitish () {
   const commit = exec('git rev-parse HEAD', { silent: true }).split('\n')[0]
   if (commit.indexOf('fatal') === -1) return commit
   return 'master'
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath))
 }
 
 module.exports = getDefaults


### PR DESCRIPTION
This allow to read dynamically changes package.json file.

For example, in runtime when we run script that update package.json version and create release on github.

* In case, when we use `require`, it will holds content of package.json and not change it while script not started again. So, we can't read actual version from it, because it changed in runtime

* In case, when we use `read`, we always read fresh state of package.json with latest actual changes