### PR TITLE
chore!: drop support for Node versions <20, update deps, patch sec vulns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,14 @@
 version: 2
 updates:
   # Enable version updates for npm
-  - package-ecosystem: 'npm'
+  - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
+    directory: "/"
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
-    versioning-strategy: 'increase'
-
+      interval: "daily"
   # Enable updates to github actions
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'daily'
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    versioning-strategy: 'increase'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,17 @@
 version: 2
 updates:
   # Enable version updates for npm
-  - package-ecosystem: "npm"
+  - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/"
+    directory: '/'
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    versioning-strategy: 'increase'
+
   # Enable updates to github actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    versioning-strategy: 'increase'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,13 @@
 name: tests
 
 on:
+  pull_request:
   push:
-    branches: '**'
+    branches:
+      - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,11 @@
 name: tests
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
+    branches: '**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -17,13 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20]
+        node: [20, 22, 24]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node }}
-    - run: npm i
-    - run: npm test
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm i
+      - run: npm test

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
+node_modules/
+test/
+CONTRIBUTING.md
 rocket.png

--- a/package.json
+++ b/package.json
@@ -21,29 +21,29 @@
     "Ted Janeczko <tjaneczko@brightcove.com>"
   ],
   "dependencies": {
-    "@octokit/rest": "^19.0.5",
-    "changelog-parser": "^3.0.0",
+    "@octokit/rest": "^20.1.2",
+    "changelog-parser": "^3.0.1",
     "deep-extend": "^0.6.0",
-    "gauge": "^v5.0.0",
-    "gh-release-assets": "^2.0.0",
-    "ghauth": "^5.0.0",
-    "github-url-to-object": "^4.0.4",
-    "inquirer": "^8.0.0",
-    "shelljs": "^0.8.4",
-    "update-notifier": "^5.0.0",
-    "yargs": "^17.0.0"
+    "gauge": "^5.0.2",
+    "gh-release-assets": "^2.0.1",
+    "ghauth": "^6.0.13",
+    "github-url-to-object": "^4.0.6",
+    "inquirer": "^8.2.6",
+    "shelljs": "^0.10.0",
+    "update-notifier": "^5.1.0",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "git-pull-or-clone": "^2.0.1",
+    "git-pull-or-clone": "^2.0.2",
     "npm-run-all": "^4.1.5",
     "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "tap-arc": "^0.3.4",
-    "tape": "^5.0.1",
-    "tmp": "v0.2.1"
+    "standard": "^17.1.2",
+    "tap-arc": "^1.3.2",
+    "tape": "^5.9.0",
+    "tmp": "^0.2.3"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
This PR performs a number of maintenance operations:
- Drops support for Node versions below 20 (EOL).
- Patches 6 `@octokit` security vulnerabilities. There's 1 remaining vulnerability being imported by `update-notifier` but updating it would require switching this package to ESM.
- Updates all dependencies to latest Node v20 compatible versions.
- Update GH Actions to latest versions.