### PR TITLE
feat: add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ var options = {
   repo: 'gh-release',
   owner: 'ungoldman',
   endpoint: 'https://api.github.com', // for GitHub enterprise, use http(s)://hostname/api/v3
-  proxy: true // true will use environment variables, or string to specify a specific address
+  proxy: true // true will use environment variables
 }
 
 // options can also be just an empty object
@@ -154,6 +154,10 @@ All default values taken from `package.json` unless specified otherwise.
 | `endpoint` | GitHub API endpoint URL | https://api.github.com |
 
 Override defaults with flags (CLI) or the `options` object (node).
+
+## Proxy
+
+If this option is specified, a proxied fetch client will be created using the `EnvHttpProxyAgent` class from [undici](https://github.com/nodejs/undici). This class will make use of your environment variables (for instance `http_proxy`) when making the fetch call. More information about this class and how it functions can be found [here](https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent.md).
 
 ## Standards
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ Options:
   -b, --body              text of release body
   -o, --owner             repo owner
   -r, --repo              repo name
-  -d, --draft             publish as draft                          [default: false]
-  -p, --prerelease        publish as prerelease                     [default: false]
-  -w, --workpath          path to working directory                 [default: current directory]
-  -e, --endpoint          GitHub API endpoint URL                   [default: "https://api.github.com"]
-  -a, --assets            comma-delimited list of assets to upload  [default: false]
-  --dry-run               dry run (stops before release step)       [default: false]
-  -y, --yes               bypass confirmation prompt for release    [default: false]
+  -d, --draft             publish as draft                            [default: false]
+  -p, --prerelease        publish as prerelease                       [default: false]
+  -w, --workpath          path to working directory                   [default: current directory]
+  -e, --endpoint          GitHub API endpoint URL                     [default: "https://api.github.com"]
+  --proxy                 Use a proxy with your environment variables [default: false]
+  -a, --assets            comma-delimited list of assets to upload    [default: false]
+  --dry-run               dry run (stops before release step)         [default: false]
+  -y, --yes               bypass confirmation prompt for release      [default: false]
   -h, --help              Show help
   -v, --version           Show version number
 ```
@@ -109,7 +110,8 @@ var options = {
   prerelease: false,
   repo: 'gh-release',
   owner: 'ungoldman',
-  endpoint: 'https://api.github.com' // for GitHub enterprise, use http(s)://hostname/api/v3
+  endpoint: 'https://api.github.com', // for GitHub enterprise, use http(s)://hostname/api/v3
+  proxy: true // true will use environment variables, or string to specify a specific address
 }
 
 // options can also be just an empty object

--- a/bin/lib/get-defaults.js
+++ b/bin/lib/get-defaults.js
@@ -71,6 +71,7 @@ function getDefaults (workPath, isEnterprise, callback) {
       dryRun: false,
       yes: false,
       endpoint: 'https://api.github.com',
+      proxy: false,
       workpath: process.cwd(),
       prerelease: false,
       draft: false,

--- a/bin/lib/yargs.js
+++ b/bin/lib/yargs.js
@@ -60,6 +60,11 @@ module.exports = require('yargs')
       default: 'https://api.github.com',
       describe: 'GitHub API endpoint URL'
     },
+    proxy: {
+      type: 'boolean',
+      default: false,
+      description: 'Use a proxy, uses your environment variables'
+    },
     a: {
       alias: 'assets',
       type: 'string',

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "Ted Janeczko <tjaneczko@brightcove.com>"
   ],
   "dependencies": {
-    "@octokit/rest": "^20.1.2",
+    "@octokit/rest": "^22.0.0",
     "changelog-parser": "^3.0.1",
     "deep-extend": "^0.6.0",
     "gauge": "^5.0.2",
@@ -30,6 +30,7 @@
     "github-url-to-object": "^4.0.6",
     "inquirer": "^8.2.6",
     "shelljs": "^0.10.0",
+    "undici": "^7.15.0",
     "update-notifier": "^5.1.0",
     "yargs": "^17.7.2"
   },


### PR DESCRIPTION
adds a new flag for some proxy support

went based off of the example shown here https://github.com/octokit/rest.js/issues/43

makes use of https://github.com/nodejs/undici/blob/main/docs/docs/api/EnvHttpProxyAgent.md to just pull the proxy endpoint based on the users environment variables