### PR TITLE
feat!: default the publish prompt to yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ body:
 * test: testing latest CLI output
 * deps: gh-release@8
 
-? publish release to github? yes
+publish release to github? (Y/n)
 https://github.com/ungoldman/gh-release-test/releases/tag/v1.0.9
 ```
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { stdin, stdout } from 'node:process'
 import { createInterface } from 'node:readline/promises'
-import { type CliDeps, run } from './cli.js'
+import { type CliDeps, isConfirmed, run } from './cli.js'
 import Release from './index.js'
 
 const deps: CliDeps = {
@@ -12,9 +12,9 @@ const deps: CliDeps = {
   progress: (line) => process.stderr.write(`${process.stderr.isTTY ? '\r' : ''}${line}`),
   confirm: async (question) => {
     const rl = createInterface({ input: stdin, output: stdout })
-    const answer = await rl.question(`${question} `)
+    const answer = await rl.question(`${question} (Y/n) `)
     rl.close()
-    return /^y(es)?$/i.test(answer.trim())
+    return isConfirmed(answer)
   },
   exit: (code) => process.exit(code),
   release: Release

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,11 @@ function resolveToken(token: string | undefined, env: NodeJS.ProcessEnv): string
   return token ?? env.GH_RELEASE_GITHUB_API_TOKEN ?? env.GITHUB_TOKEN
 }
 
+/** Interpret a confirmation answer with a default of yes: only an explicit `n`/`no` declines. */
+export function isConfirmed(answer: string): boolean {
+  return !/^n(o)?$/i.test(answer.trim())
+}
+
 /** Run the CLI. Resolves once the release completes (or the process is told to exit). */
 export async function run(argv: string[], deps: CliDeps): Promise<void> {
   let values: ReturnType<typeof parseCliArgs>

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'node:test'
-import { type CliDeps, run } from '../src/cli.js'
+import { type CliDeps, isConfirmed, run } from '../src/cli.js'
 import Release from '../src/index.js'
 import { type MockConfig, startMockServer } from './helpers/mock-server.js'
 
@@ -50,6 +50,11 @@ function makeWorkdir(): string {
   writeFileSync(join(dir, 'CHANGELOG.md'), '## 1.0.0\n- a change\n')
   return dir
 }
+
+test('isConfirmed defaults to yes, declining only on an explicit no', () => {
+  for (const yes of ['', 'y', 'Y', 'yes', 'YES', 'sure']) assert.equal(isConfirmed(yes), true)
+  for (const no of ['n', 'N', 'no', 'NO', '  no  ']) assert.equal(isConfirmed(no), false)
+})
 
 test('--help prints usage and exits 0', async () => {
   const { deps, out, exits } = makeDeps()


### PR DESCRIPTION
Flips the "publish release to github?" confirmation to default to yes, closing #179. Pressing Enter now publishes; only an explicit `n`/`no` declines. `--yes` still bypasses the prompt entirely.

## Changes

- The publish confirmation defaults to yes. The prompt shows `(Y/n)`, and any answer that is not `n`/`no` (including an empty one) publishes. Previously only `y`/`yes` published and Enter declined.
- The answer parsing moved into a tested `isConfirmed` helper; the readline I/O stays in the spawn-only `bin.ts`.

## Breaking changes (going out in 8.0.0)

The "publish release to github?" confirmation now defaults to yes. Pressing Enter, or any answer that is not `n`/`no`, publishes the release; previously only `y`/`yes` published and an empty answer declined.

Closes #179.

## Verification

Lint, typecheck, build, and the full suite pass; coverage is at 100%. The `isConfirmed` default-yes logic is unit-tested, and the `BREAKING CHANGE` footer was verified through the release-please renderer.
