### PR TITLE
fix: handle 422 commitish, silence git stderr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,9 @@ const OPTIONS: OptionsSpec = {
   }
 }
 
+/** Shared no-op used to silence Octokit's logger. */
+const noop = (): void => {}
+
 /** Report any required options that are missing. */
 function validate(options: ReleaseOptions): { missing: string[] } {
   const opts = options as Record<string, unknown>
@@ -103,7 +106,12 @@ async function runRelease(
   const token = (options.auth as Auth).token
   if (!token) return callback(new Error('missing auth info'))
 
-  const octokit = new Octokit({ auth: token, baseUrl: options.endpoint })
+  const octokit = new Octokit({
+    auth: token,
+    baseUrl: options.endpoint,
+    // gh-release surfaces errors via the callback; silence Octokit's own request logging
+    log: { debug: noop, info: noop, warn: noop, error: noop }
+  })
   const owner = options.owner as string
   const repo = options.repo as string
 
@@ -111,7 +119,8 @@ async function runRelease(
     await octokit.repos.getCommit({ owner, repo, ref: options.target_commitish as string })
   } catch (err) {
     const e = err as HttpError
-    if (e.status === 404) {
+    // GitHub returns 404 when the repo is unreachable and 422 for a ref/SHA that does not resolve
+    if (e.status === 404 || e.status === 422) {
       return callback(
         new Error(`Target commitish ${options.target_commitish} not found in ${owner}/${repo}`)
       )

--- a/src/lib/get-defaults.ts
+++ b/src/lib/get-defaults.ts
@@ -27,7 +27,11 @@ function readJson(filePath: string): Record<string, unknown> {
 /** Current HEAD commit, or `master` when not in a git repo. */
 export function getTargetCommitish(): string {
   try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).split('\n')[0]
+    // ignore stderr so git's own "fatal: not a git repository" is not surfaced before the fallback
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).split('\n')[0]
   } catch {
     return 'master'
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -72,7 +72,15 @@ test('errors when the target commitish is not found', async () => {
   })
 })
 
-test('passes through a non-404 getCommit error', async () => {
+test('treats a 422 from getCommit as a missing commitish', async () => {
+  // GitHub returns 422 (not 404) for a ref/SHA that does not resolve
+  await withServer({ getCommit: { status: 422 } }, async (url) => {
+    const { err } = await release(baseOptions(url))
+    assert.equal(err?.message, 'Target commitish main not found in o/r')
+  })
+})
+
+test('passes through any other getCommit error', async () => {
   await withServer({ getCommit: { status: 500, body: { message: 'boom' } } }, async (url) => {
     const { err } = await release(baseOptions(url))
     assert.equal((err as { status?: number }).status, 500)


### PR DESCRIPTION
Two robustness fixes surfaced by live-testing the 8.0.0 build against a real repo.

## Changes

- **A bad `target_commitish` now reports cleanly.** GitHub's `getCommit` returns `422` (not `404`) for a ref or SHA that doesn't resolve, so the friendly `Target commitish <x> not found in <owner>/<repo>` message never fired and callers saw the raw Octokit error. The catch now treats `422` like `404`. Octokit's own request logging is also silenced (gh-release reports errors through its callback), so the stray `GET ... 422 ...` line no longer prints.
- **`getTargetCommitish` no longer leaks git's stderr.** Run outside a git repo, `git rev-parse HEAD` printed `fatal: not a git repository` before falling back to `master`; its stderr is now ignored.

## Verification

Lint, typecheck, build, and the full suite pass; coverage is at 100%. Verified live against ungoldman/gh-release-test: a nonexistent ref or SHA now yields `Target commitish ... not found` with no Octokit noise, and a run in a non-git directory falls back to `master` silently.
