### PR TITLE
feat: add --tag-prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Create a GitHub Release for a Node package.
 
 Options:
   -t, --tag_name <tag>          tag for this release
+      --tag-prefix <prefix>     prefix for the derived tag and title (default "v")
   -c, --target_commitish <ref>  commitish value for tag
   -n, --name <name>             text of release title
   -b, --body <body>             text of release body
@@ -140,9 +141,9 @@ All default values are taken from `package.json` unless specified otherwise.
 
 | name | description | default |
 | ---: | ----------- | ------- |
-| `tag_name` | release tag | 'v' + `version` |
+| `tag_name` | release tag | tag prefix + `version` |
 | `target_commitish` | commitish value to tag | HEAD of current branch |
-| `name` | release title | 'v' + `version` |
+| `name` | release title | tag prefix + `version` |
 | `body` | release text | `CHANGELOG.md` section matching `version` (empty if no changelog) |
 | `owner` | repo owner | repo owner in `repository` |
 | `repo` | repo name | repo name in `repository` |
@@ -152,6 +153,15 @@ All default values are taken from `package.json` unless specified otherwise.
 | `endpoint` | GitHub API endpoint URL | https://api.github.com |
 
 Override defaults with flags (CLI) or the `options` object (Node).
+
+The tag and title are the `version` prefixed with `v`. Change the prefix with `--tag-prefix <prefix>` (CLI) or `tagPrefix` (Node), and pass an empty string to drop it (so the tag is the bare `version`). Override the tag or title outright with `--tag_name`/`--name`.
+
+```
+gh-release --tag-prefix ''               # 1.2.3 instead of v1.2.3
+gh-release --tag-prefix 'service/env/'   # service/env/1.2.3, for scoped or monorepo tags
+```
+
+Git allows slashes in tag names, so a prefix like `service/env/` produces the tag `service/env/1.2.3`. The title takes the same value, so pair it with `--name` if you want a cleaner one.
 
 `CHANGELOG.md` is optional. Without it, gh-release tags from the `package.json` version with an empty body. When it is present, the matching section is used, and that section may itself be empty. Either way the CLI prints a warning when the body ends up empty.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,7 @@ export async function run(argv: string[], deps: CliDeps): Promise<void> {
 
   let defaults: Awaited<ReturnType<typeof getDefaults>>
   try {
-    defaults = await getDefaults(workpath, isEnterprise)
+    defaults = await getDefaults(workpath, isEnterprise, values['tag-prefix'])
   } catch (err) {
     deps.stderr((err as Error).message)
     return deps.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export interface ReleaseOptions {
   workpath?: string
   assets?: AssetInput[] | false
   cli?: boolean
+  /** Prefix for the derived tag and title (default `v`; `''` for none). */
+  tagPrefix?: string
 }
 
 /** Completion callback. `result` is the GitHub createRelease response data. */
@@ -88,7 +90,7 @@ function Release(options: ReleaseOptions, callback: ReleaseCallback): EventEmitt
 
   const workpath = options.workpath ?? (OPTIONS.defaults.workpath as string)
   const isEnterprise = !!options.endpoint && options.endpoint !== OPTIONS.defaults.endpoint
-  getDefaults(workpath, isEnterprise)
+  getDefaults(workpath, isEnterprise, options.tagPrefix)
     .then((defaults) => runRelease({ ...defaults, ...options }, emitter, callback))
     .catch((err: Error) => callback(err))
 

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -14,6 +14,7 @@ Create a GitHub Release for a Node package.
 
 Options:
   -t, --tag_name <tag>          tag for this release
+      --tag-prefix <prefix>     prefix for the derived tag and title (default "v")
   -c, --target_commitish <ref>  commitish value for tag
   -n, --name <name>             text of release title
   -b, --body <body>             text of release body
@@ -38,6 +39,7 @@ export function parseCliArgs(argv: string[]) {
     allowPositionals: false,
     options: {
       tag_name: { type: 'string', short: 't' },
+      'tag-prefix': { type: 'string' },
       target_commitish: { type: 'string', short: 'c' },
       name: { type: 'string', short: 'n' },
       body: { type: 'string', short: 'b' },

--- a/src/lib/get-defaults.ts
+++ b/src/lib/get-defaults.ts
@@ -86,8 +86,15 @@ function parseRepo(
   return { owner, repo }
 }
 
-/** Derive release defaults for a package directory. Throws on validation failure. */
-export async function getDefaults(workPath: string, isEnterprise: boolean): Promise<Defaults> {
+/**
+ * Derive release defaults for a package directory. `tagPrefix` is prepended to the
+ * derived tag and title (default `v`; pass `''` for none). Throws on validation failure.
+ */
+export async function getDefaults(
+  workPath: string,
+  isEnterprise: boolean,
+  tagPrefix = 'v'
+): Promise<Defaults> {
   const pkg = readJson(resolve(workPath, 'package.json'))
   if (!Object.hasOwn(pkg, 'repository')) {
     throw new Error(
@@ -115,7 +122,8 @@ export async function getDefaults(workPath: string, isEnterprise: boolean): Prom
   const { body, version } = await resolveRelease(
     resolve(workPath, 'CHANGELOG.md'),
     sourceVersion,
-    sourceLabel
+    sourceLabel,
+    tagPrefix
   )
 
   return {
@@ -143,13 +151,14 @@ export async function getDefaults(workPath: string, isEnterprise: boolean): Prom
 async function resolveRelease(
   changelogPath: string,
   sourceVersion: string | undefined,
-  sourceLabel: string
+  sourceLabel: string,
+  tagPrefix: string
 ): Promise<{ body: string; version: string }> {
   if (!existsSync(changelogPath)) {
     if (!sourceVersion) {
       throw new Error(`${sourceLabel} has no version to release`)
     }
-    return { body: '', version: `v${sourceVersion}` }
+    return { body: '', version: `${tagPrefix}${sourceVersion}` }
   }
 
   let result: Awaited<ReturnType<typeof parseChangelog>>
@@ -178,5 +187,5 @@ async function resolveRelease(
     )
   }
 
-  return { body: log.body, version: `v${log.version}` }
+  return { body: log.body, version: `${tagPrefix}${log.version}` }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -275,6 +275,24 @@ test('--generate-notes requests generated notes and skips the empty-body warning
   }
 })
 
+test('--tag-prefix changes the derived tag', async () => {
+  const server = await startMockServer({})
+  try {
+    const { deps, exits } = makeDeps()
+    await run(
+      ['-w', fixture('basic'), '-e', server.url, '--token', 'x', '-y', '--tag-prefix', ''],
+      deps
+    )
+    assert.deepEqual(exits, [0])
+    const createReq = server.requests.find(
+      (r) => r.method === 'POST' && r.url.endsWith('/releases')
+    )
+    assert.ok(createReq && createReq.body.includes('"tag_name":"0.0.0"'))
+  } finally {
+    await server.close()
+  }
+})
+
 test('uploads assets and reports progress', async () => {
   const dir = makeWorkdir()
   writeFileSync(join(dir, 'a.txt'), 'aaa')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -181,6 +181,25 @@ test('non-cli path derives defaults then creates a release', async () => {
   })
 })
 
+test('non-cli path applies the tagPrefix option', async () => {
+  const server = await startMockServer({})
+  try {
+    const { err } = await release({
+      workpath: join(import.meta.dirname, 'fixtures', 'basic'),
+      auth: { token: 'test-token' },
+      endpoint: server.url,
+      tagPrefix: ''
+    })
+    assert.equal(err, null)
+    const createReq = server.requests.find(
+      (r) => r.method === 'POST' && r.url.endsWith('/releases')
+    )
+    assert.ok(createReq && createReq.body.includes('"tag_name":"0.0.0"'))
+  } finally {
+    await server.close()
+  }
+})
+
 test('non-cli path falls back to the default workpath (cwd)', async () => {
   await withServer({}, async (url) => {
     // no workpath: derives defaults from this package's own root

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -210,6 +210,13 @@ test('rejects a non-empty unreleased section', async () => {
   await assert.rejects(getDefaults(fixture('unreleased'), false), /Unreleased changes detected/)
 })
 
+test('applies a custom tag prefix to the tag and title', async () => {
+  assert.equal((await getDefaults(fixture('basic'), false, '')).tag_name, '0.0.0')
+  const prefixed = await getDefaults(fixture('basic'), false, 'release-')
+  assert.equal(prefixed.tag_name, 'release-0.0.0')
+  assert.equal(prefixed.name, 'release-0.0.0')
+})
+
 test('getTargetCommitish returns the current HEAD', () => {
   assert.match(getTargetCommitish(), /^[0-9a-f]{7,40}$/)
 })
@@ -277,6 +284,11 @@ test('parses flags and short aliases', () => {
 
 test('throws on an unknown flag', () => {
   assert.throws(() => parseCliArgs(['--nope']))
+})
+
+test('parses the --tag-prefix option', () => {
+  assert.equal(parseCliArgs(['--tag-prefix', ''])['tag-prefix'], '')
+  assert.equal(parseCliArgs(['--tag-prefix', 'rel-'])['tag-prefix'], 'rel-')
 })
 
 test('parses the --generate-notes flag', () => {


### PR DESCRIPTION
Adds `--tag-prefix` so projects that tag without a `v` prefix can use the derived defaults instead of overriding `--tag_name` and `--name` by hand. Closes #193.

## Changes

- `--tag-prefix <prefix>` (CLI) and `tagPrefix` (Node), default `v`. It prefixes the derived tag and title; pass an empty string for none, so the tag is the bare `package.json` version. `--tag_name`/`--name` still override outright.
- The prefix is applied in one place (`getDefaults`), threaded from both the CLI and the programmatic entry points.

Non-breaking: the default `v` keeps the current behavior.

## Usage

```
gh-release --tag-prefix ''               # tag 1.2.3 instead of v1.2.3
gh-release --tag-prefix=                 # same, equals form
gh-release --tag-prefix 'service/env/'   # service/env/1.2.3, for scoped or monorepo tags
```

Git allows slashes in tag names, so a prefix like `service/env/` produces the tag `service/env/1.2.3` (the title takes the same value; pair it with `--name` for a cleaner one). Confirmed end to end against a real repo.

## Verification

Lint, typecheck, build, and the full suite pass; coverage is at 100%. Covered at all four seams: `getDefaults` with a custom and an empty prefix, the arg parser, the CLI flag through to the created tag, and the programmatic `tagPrefix` option.
