### PR TITLE
test: remove temp dirs after each run

### DIFF
--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { test } from 'node:test'
+import { makeTmpDir } from './helpers/tmp.js'
 
 const bin = join(import.meta.dirname, '..', 'dist', 'bin.js')
 
@@ -23,8 +23,8 @@ test('bin --version prints the version and exits 0', () => {
   assert.match(res.stdout.trim(), /^\d+\.\d+\.\d+$/)
 })
 
-test('bin exits 1 when no token is available', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-bin-'))
+test('bin exits 1 when no token is available', (t) => {
+  const dir = makeTmpDir(t, 'gh-release-bin-')
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'r', version: '1.0.0', repository: 'https://github.com/o/r.git' })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { test } from 'node:test'
+import { type TestContext, test } from 'node:test'
 import { type CliDeps, isConfirmed, run } from '../src/cli.js'
 import Release from '../src/index.js'
 import { type MockConfig, startMockServer } from './helpers/mock-server.js'
+import { makeTmpDir } from './helpers/tmp.js'
 
 const fixture = (name: string) => join(import.meta.dirname, 'fixtures', name)
 
@@ -41,8 +41,8 @@ async function withServer(
 }
 
 /** A self-contained package directory the release flow can run against. */
-function makeWorkdir(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-cli-'))
+function makeWorkdir(t: TestContext): string {
+  const dir = makeTmpDir(t, 'gh-release-cli-')
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'r', version: '1.0.0', repository: 'https://github.com/o/r.git' })
@@ -77,8 +77,8 @@ test('an unknown flag exits 1 with usage', async () => {
   assert.deepEqual(exits, [1])
 })
 
-test('missing package.json exits 1', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-empty-'))
+test('missing package.json exits 1', async (t) => {
+  const dir = makeTmpDir(t, 'gh-release-empty-')
   const { deps, out, exits } = makeDeps()
   await run(['-w', dir], deps)
   assert.ok(out.join('\n').includes('Must be run in a directory'))
@@ -221,8 +221,8 @@ test('a release error exits 1', async () => {
 })
 
 /** A package dir whose changelog entry has an empty body. */
-function makeEmptyBodyWorkdir(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-cli-'))
+function makeEmptyBodyWorkdir(t: TestContext): string {
+  const dir = makeTmpDir(t, 'gh-release-cli-')
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'r', version: '1.0.0', repository: 'https://github.com/o/r.git' })
@@ -231,8 +231,8 @@ function makeEmptyBodyWorkdir(): string {
   return dir
 }
 
-test('warns but still releases when the body is empty', async () => {
-  const dir = makeEmptyBodyWorkdir()
+test('warns but still releases when the body is empty', async (t) => {
+  const dir = makeEmptyBodyWorkdir(t)
   await withServer({}, async (url) => {
     const { deps, errs, exits } = makeDeps()
     await run(['-w', dir, '-e', url, '--token', 'x', '-y'], deps)
@@ -241,8 +241,8 @@ test('warns but still releases when the body is empty', async () => {
   })
 })
 
-test('releases without a CHANGELOG.md, warning and using package.json', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-cli-'))
+test('releases without a CHANGELOG.md, warning and using package.json', async (t) => {
+  const dir = makeTmpDir(t, 'gh-release-cli-')
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'r', version: '1.0.0', repository: 'https://github.com/o/r.git' })
@@ -257,8 +257,8 @@ test('releases without a CHANGELOG.md, warning and using package.json', async ()
   })
 })
 
-test('--generate-notes requests generated notes and skips the empty-body warning', async () => {
-  const dir = makeEmptyBodyWorkdir()
+test('--generate-notes requests generated notes and skips the empty-body warning', async (t) => {
+  const dir = makeEmptyBodyWorkdir(t)
   const server = await startMockServer({})
   try {
     const { deps, errs, exits } = makeDeps()
@@ -293,8 +293,8 @@ test('--tag-prefix changes the derived tag', async () => {
   }
 })
 
-test('uploads assets and reports progress', async () => {
-  const dir = makeWorkdir()
+test('uploads assets and reports progress', async (t) => {
+  const dir = makeWorkdir(t)
   writeFileSync(join(dir, 'a.txt'), 'aaa')
   await withServer({}, async (url) => {
     const { deps, out, progress, exits } = makeDeps()

--- a/test/helpers/tmp.ts
+++ b/test/helpers/tmp.ts
@@ -1,0 +1,14 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { TestContext } from 'node:test'
+
+/**
+ * Make a temp dir and remove it after the test, pass or throw. `force` also
+ * covers the case where a CHANGELOG.md path is itself a directory.
+ */
+export function makeTmpDir(t: TestContext, prefix = 'gh-release-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+  return dir
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import Release, { ghRelease, type ReleaseOptions } from '../src/index.js'
 import { type MockConfig, startMockServer } from './helpers/mock-server.js'
+import { makeTmpDir } from './helpers/tmp.js'
 
 test('exposes the same function as the default and the ghRelease named export', () => {
   assert.equal(ghRelease, Release)
@@ -136,8 +136,8 @@ test('passes through a generic createRelease error', async () => {
   })
 })
 
-test('uploads string and object assets and relays their events', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('uploads string and object assets and relays their events', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(join(dir, 'a.txt'), 'aaa')
   writeFileSync(join(dir, 'b.txt'), 'bbb')
   await withServer({}, async (url) => {
@@ -161,8 +161,8 @@ test('treats an empty assets array as no assets', async () => {
   })
 })
 
-test('errors when an asset file is missing', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('errors when an asset file is missing', async (t) => {
+  const dir = makeTmpDir(t)
   await withServer({}, async (url) => {
     const { err } = await release(baseOptions(url, { workpath: dir, assets: ['missing.txt'] }))
     assert.ok(err instanceof Error)

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -1,19 +1,19 @@
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { test } from 'node:test'
+import { type TestContext, test } from 'node:test'
 import fc from 'fast-check'
 import { type ReleaseOptions, validate } from '../src/index.js'
 import { parseCliArgs, usage, version } from '../src/lib/args.js'
 import { getDefaults, getTargetCommitish } from '../src/lib/get-defaults.js'
 import { preview } from '../src/lib/preview.js'
+import { makeTmpDir } from './helpers/tmp.js'
 
 const fixture = (name: string) => join(import.meta.dirname, 'fixtures', name)
 
 /** Write a temp package dir with a given `repository` value and a matching changelog. */
-function pkgDir(repository: unknown): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+function pkgDir(t: TestContext, repository: unknown): string {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'r', version: '1.0.0', repository })
@@ -43,27 +43,27 @@ test('reads an enterprise (non-github) repository host', async () => {
   assert.equal(defaults.repo, 'repo')
 })
 
-test('reads an scp-like git@host:owner/repo.git repository', async () => {
-  const defaults = await getDefaults(pkgDir('git@github.com:o/r.git'), false)
+test('reads an scp-like git@host:owner/repo.git repository', async (t) => {
+  const defaults = await getDefaults(pkgDir(t, 'git@github.com:o/r.git'), false)
   assert.equal(defaults.owner, 'o')
   assert.equal(defaults.repo, 'r')
 })
 
-test('reads a github:owner/repo shorthand repository', async () => {
-  const defaults = await getDefaults(pkgDir('github:o/r'), false)
+test('reads a github:owner/repo shorthand repository', async (t) => {
+  const defaults = await getDefaults(pkgDir(t, 'github:o/r'), false)
   assert.equal(defaults.owner, 'o')
   assert.equal(defaults.repo, 'r')
 })
 
-test('reads a bare owner/repo shorthand repository', async () => {
-  const defaults = await getDefaults(pkgDir('o/r'), false)
+test('reads a bare owner/repo shorthand repository', async (t) => {
+  const defaults = await getDefaults(pkgDir(t, 'o/r'), false)
   assert.equal(defaults.owner, 'o')
   assert.equal(defaults.repo, 'r')
 })
 
-test('rejects a malformed repository url', async () => {
+test('rejects a malformed repository url', async (t) => {
   await assert.rejects(
-    getDefaults(pkgDir('https://'), false),
+    getDefaults(pkgDir(t, 'https://'), false),
     /repository defined in your package.json is invalid/
   )
 })
@@ -85,15 +85,15 @@ test('rejects an invalid repository string', async () => {
   )
 })
 
-test('rejects a package.json with no repository field', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('rejects a package.json with no repository field', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', version: '1.0.0' }))
   writeFileSync(join(dir, 'CHANGELOG.md'), '## 1.0.0\n- a\n')
   await assert.rejects(getDefaults(dir, false), /must define a repository/)
 })
 
-test('rejects a repository object with no url', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('rejects a repository object with no url', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', version: '1.0.0', repository: { type: 'git' } })
@@ -112,8 +112,8 @@ test('rejects a non-github host when not enterprise', async () => {
   )
 })
 
-test('rejects a repository url missing the repo segment', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('rejects a repository url missing the repo segment', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', version: '1.0.0', repository: 'https://github.com/foo' })
@@ -125,8 +125,8 @@ test('rejects a repository url missing the repo segment', async () => {
   )
 })
 
-test('accepts a lerna.json version matching the changelog', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('accepts a lerna.json version matching the changelog', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', version: '9.9.9', repository: 'https://github.com/o/r.git' })
@@ -155,8 +155,8 @@ test('rejects a changelog with no recognized version entries', async () => {
   await assert.rejects(getDefaults(fixture('no-versions'), false), /no recognized version entries/)
 })
 
-test('wraps a present-but-unreadable changelog error', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('wraps a present-but-unreadable changelog error', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', version: '1.0.0', repository: 'https://github.com/o/r.git' })
@@ -166,8 +166,8 @@ test('wraps a present-but-unreadable changelog error', async () => {
   await assert.rejects(getDefaults(dir, false), /Could not read CHANGELOG.md: /)
 })
 
-test('releases without a CHANGELOG.md, from the package.json version', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('releases without a CHANGELOG.md, from the package.json version', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', version: '2.3.4', repository: 'https://github.com/o/r.git' })
@@ -179,8 +179,8 @@ test('releases without a CHANGELOG.md, from the package.json version', async () 
   assert.equal(defaults.name, 'v2.3.4')
 })
 
-test('rejects a missing CHANGELOG.md when package.json has no version', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('rejects a missing CHANGELOG.md when package.json has no version', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', repository: 'https://github.com/o/r.git' })
@@ -188,8 +188,8 @@ test('rejects a missing CHANGELOG.md when package.json has no version', async ()
   await assert.rejects(getDefaults(dir, false), /package.json has no version to release/)
 })
 
-test('allows an empty release body', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-'))
+test('allows an empty release body', async (t) => {
+  const dir = makeTmpDir(t)
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({ name: 'x', version: '1.0.0', repository: 'https://github.com/o/r.git' })
@@ -221,8 +221,8 @@ test('getTargetCommitish returns the current HEAD', () => {
   assert.match(getTargetCommitish(), /^[0-9a-f]{7,40}$/)
 })
 
-test('getTargetCommitish falls back to master outside a git repo', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'gh-release-nogit-'))
+test('getTargetCommitish falls back to master outside a git repo', (t) => {
+  const dir = makeTmpDir(t, 'gh-release-nogit-')
   const cwd = process.cwd()
   process.chdir(dir)
   try {


### PR DESCRIPTION
The `node:test` suites created `mkdtempSync` working dirs under the OS temp dir and never removed them, so every run left temp dirs behind. This cleans them up reliably on both success and failure.

Changes:
- Add `test/helpers/tmp.ts` with `makeTmpDir(t, prefix?)`, which creates the dir and registers removal via the test context's `t.after(...)`. Removal uses `rmSync(dir, { recursive: true, force: true })`, so it handles non-empty dirs and the case where a `CHANGELOG.md` path is itself a directory.
- Route every temp-dir site through the helper: direct in-test creations and the `makeWorkdir` / `makeEmptyBodyWorkdir` / `pkgDir` helpers (now threaded with the `t` context).
- No behavior or assertion changes. Test files only, no production or config changes.

Verification:
- `npm test` green (lint, typecheck, build, 80 tests).
- `npm run coverage` stays at 100% (statements, branches, functions, lines).
- Temp-dir leak fixed: a run with cleanup disabled leaks 21 `gh-release*` dirs (one per `mkdtempSync` site), a run with cleanup leaves 0.
